### PR TITLE
Use ip address to look up zone

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -42,7 +42,11 @@ type Registry struct {
 // "aws" or "unknown".
 func (r *Registry) LookupPlatform(ctx context.Context) (Platform, error) {
 	v, err := r.platform.load("platform", r.ttl(), func() (interface{}, error) {
-		return whereAmI()
+		subnets, err := r.LookupSubnets(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return whereAmI(subnets)
 	})
 	p, _ := v.(Platform)
 	return p, err

--- a/registry_test.go
+++ b/registry_test.go
@@ -42,7 +42,7 @@ var (
 
 func TestRegistryLookupPlatform(t *testing.T) {
 	cacheMisses := uint32(0)
-	r := getTestRegistry(&cacheMisses)
+	r := newTestRegistry(&cacheMisses)
 	ctx := context.Background()
 
 	p, err := r.LookupPlatform(ctx)
@@ -62,7 +62,7 @@ func TestRegistryLookupPlatform(t *testing.T) {
 
 func TestRegistryLookupZone(t *testing.T) {
 	cacheMisses := uint32(0)
-	r := getTestRegistry(&cacheMisses)
+	r := newTestRegistry(&cacheMisses)
 	ctx := context.Background()
 
 	z, err := r.LookupZone(ctx)
@@ -77,7 +77,7 @@ func TestRegistryLookupZone(t *testing.T) {
 
 func TestRegistryLookupSubnets(t *testing.T) {
 	cacheMisses := uint32(0)
-	r := getTestRegistry(&cacheMisses)
+	r := newTestRegistry(&cacheMisses)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -131,7 +131,7 @@ func BenchmarkRegistry(b *testing.B) {
 	}
 }
 
-func getTestRegistry(cacheMisses *uint32) *Registry {
+func newTestRegistry(cacheMisses *uint32) *Registry {
 	return &Registry{
 		Resolver: resolverFunc(func(ctx context.Context, name string) ([]string, error) {
 			switch name {

--- a/vpcinfo.go
+++ b/vpcinfo.go
@@ -177,7 +177,7 @@ type aws struct {
 	zone Zone
 }
 
-func (a aws) String() string { return "aws" }
+func (aws) String() string { return "aws" }
 
 func (a aws) LookupZone(ctx context.Context) (Zone, error) {
 	return a.zone, nil

--- a/vpcinfo.go
+++ b/vpcinfo.go
@@ -113,15 +113,15 @@ func zoneFromSubnets(subnets []Subnet) (Zone, error) {
 	}
 
 	for _, addr := range addrs {
-		for _, subnet := range subnets {
-			var ip net.IP
-			switch v := addr.(type) {
-			case *net.IPNet:
-				ip = v.IP
-			case *net.IPAddr:
-				ip = v.IP
-			}
+		var ip net.IP
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		}
 
+		for _, subnet := range subnets {
 			if subnet.CIDR.Contains(ip) {
 				return Zone(subnet.Zone), nil
 			}


### PR DESCRIPTION
## Description
This change updates the `vpcinfo` library to get the current AZ by matching the host or container's ip address to the subnets found in DNS. If no match is possible, then it falls back to the existing behavior of hitting the ec2 metadata endpoint.

This change is needed because we're trying to block ec2 metadata access in onebox cells.

## Testing Done
Tested end-to-end in my onebox cell and verified that centrifuge could get the AZ without hitting the ec2 metadata service.